### PR TITLE
Add a workaround for ShadowTheAge/YAFC#195

### DIFF
--- a/prototypes/entity/power/accumulator.lua
+++ b/prototypes/entity/power/accumulator.lua
@@ -18,7 +18,7 @@ local inputs = {
 }
 
 local tier_map = {
-    ["accumulator"] = {1, 2},
+    ["accumulator"] = {1, 2, ""},
     ["large-accumulator"] = {1, 2, 1},
     ["large-accumulator-2"] = {2, 3, 1},
     ["large-accumulator-3"] = {3, 4, 1},


### PR DESCRIPTION
Lua 5.2, which [YAFC](https://github.com/ShadowTheAge/yafc) uses, does not appear to support concatenating with nil. I'm not really comfortable trying to upgrade YAFC's Lua to a newer version, and my brief web searches have suggested that concatenating with nil isn't supposed to work in any version of Lua.

This change makes YAFC able to load the combination of Nullius and reskins-bobs.